### PR TITLE
bugfix: Tasks were not working with tfidf (forgotten passing of config)

### DIFF
--- a/tasks/anssel.py
+++ b/tasks/anssel.py
@@ -80,7 +80,7 @@ class AnsSelTask(AbstractTask):
     def build_model(self, module_prep_model, optimizer='adam', fix_layers=[], do_compile=True):
         if self.c['ptscorer'] is None:
             # non-neural model
-            return module_prep_model(self.vocab)
+            return module_prep_model(self.vocab, self.c)
 
         # ranking losses require wide output domain
         oact = 'sigmoid' if self.c['loss'] == 'binary_crossentropy' else 'linear'

--- a/tasks/hypev.py
+++ b/tasks/hypev.py
@@ -55,7 +55,7 @@ class HypEvTask(AbstractTask):
     def build_model(self, module_prep_model, optimizer='adam', fix_layers=[], do_compile=True):
         if self.c['ptscorer'] is None:
             # non-neural model
-            return module_prep_model(self.vocab)
+            return module_prep_model(self.vocab, self.c)
 
         # ranking losses require wide output domain
         oact = 'sigmoid' if self.c['loss'] == 'binary_crossentropy' else 'linear'

--- a/tasks/para.py
+++ b/tasks/para.py
@@ -53,7 +53,7 @@ class ParaphrasingTask(AbstractTask):
     def build_model(self, module_prep_model, optimizer='adam', fix_layers=[], do_compile=True):
         if self.c['ptscorer'] is None:
             # non-neural model
-            return module_prep_model(self.vocab, output='binary')
+            return module_prep_model(self.vocab, self.c, output='binary')
 
         model = self.prep_model(module_prep_model)
 

--- a/tasks/sts.py
+++ b/tasks/sts.py
@@ -100,7 +100,7 @@ class STSTask(AbstractTask):
     def build_model(self, module_prep_model, optimizer='adam', fix_layers=[], do_compile=True):
         if self.c['ptscorer'] is None:
             # non-neural model
-            return module_prep_model(self.vocab, output='classes')
+            return module_prep_model(self.vocab, self.c, output='classes')
 
         model = self.prep_model(module_prep_model)
 


### PR DESCRIPTION
Tasks (all) were not passing self.config to prep_model. That broke tfidf. 

I have not tried ubuntu task.

Error looked like this (more or less same for all tasks):

```
nadvorj1@doom4:~/tmp2/dataset-sts$ python tools/train.py termfreq anssel data/anssel/wang/train-all.csv data/anssel/wang/dev.csv inp_e_dropout=1/2 nb_epoch=1; beep
Dataset
RunID: anssel-termfreq-671c45eeeb0f576e  ({"B": "0.75", "Ddim": "2", "K1": "1.2", "balance_class": "False", "batch_size": "160", "e_add_flags": "True", "embdim": "None", "epoch_fract": "0.25", "freq_mode": "BM25", "idf": "True", "inp_e_dropout": "0.5", "inp_w_dropout": "0", "loss": "<function ranknet at 0x9c1fb18>", "mlpsum": "sum", "nb_epoch": "1", "nb_runs": "1", "ptscorer": "None", "score_mode": "overlap"})
Model
Traceback (most recent call last):
  File "tools/train.py", line 133, in <module>
    train_and_eval(runid, model_module.prep_model, task, conf)
  File "tools/train.py", line 94, in train_and_eval
    model = task.build_model(module_prep_model)
  File "/auto/ostrava1/nadvorj1/tmp2/dataset-sts/tools/tasks/anssel.py", line 83, in build_model
    return module_prep_model(self.vocab)
TypeError: prep_model() takes at least 2 arguments (1 given)
```
